### PR TITLE
types: Add a macro_rules to generate From/TryFrom implementations for TypedData

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3"
 nom = "8.0"
 rand = "0.9"
 semver = "1.0"
+thiserror = "2.0"
 tokio = { version = "1.44", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 

--- a/examples/agent_socket.rs
+++ b/examples/agent_socket.rs
@@ -6,7 +6,6 @@ use spop::{
     actions::VarScope,
     frame::{FramePayload, FrameType},
     frames::{Ack, AgentDisconnect, AgentHello, FrameCapabilities, HaproxyHello},
-    types::TypedData,
 };
 use std::{os::unix::fs::PermissionsExt, path::Path};
 use tokio::net::{UnixListener, UnixStream};
@@ -108,25 +107,18 @@ async fn handle_connection(u_stream: UnixStream) -> Result<()> {
             // Respond with Ack frame
             FrameType::Notify => {
                 if let FramePayload::ListOfMessages(messages) = &frame.payload() {
-                    let mut vars = Vec::new();
+                    // Create the Ack frame
+                    let mut ack = Ack::new(frame.metadata().stream_id, frame.metadata().frame_id);
 
                     for message in messages {
                         match message.name.as_str() {
                             "check-client-ip" => {
                                 let random_value: u32 = rand::random_range(0..100);
-                                vars.push((
-                                    VarScope::Session,
-                                    "ip_score",
-                                    TypedData::UInt32(random_value),
-                                ));
+                                ack = ack.set_var(VarScope::Session, "ip_score", random_value);
                             }
 
                             "log-request" => {
-                                vars.push((
-                                    VarScope::Transaction,
-                                    "my_var",
-                                    TypedData::String("tequila".to_string()),
-                                ));
+                                ack = ack.set_var(VarScope::Transaction, "my_var", "tequila");
                             }
 
                             _ => {
@@ -134,12 +126,6 @@ async fn handle_connection(u_stream: UnixStream) -> Result<()> {
                             }
                         }
                     }
-
-                    // Create the Ack frame
-                    let ack = vars.into_iter().fold(
-                        Ack::new(frame.metadata().stream_id, frame.metadata().frame_id),
-                        |ack, (scope, name, value)| ack.set_var(scope, name, value),
-                    );
 
                     // Create the response frame
                     println!("Sending Ack: {:#?}", ack.payload());

--- a/src/frames/ack.rs
+++ b/src/frames/ack.rs
@@ -35,11 +35,11 @@ impl Ack {
     }
 
     /// Adds a set-var action to the ACK frame
-    pub fn set_var(mut self, scope: VarScope, name: &str, value: TypedData) -> Self {
+    pub fn set_var(mut self, scope: VarScope, name: &str, value: impl Into<TypedData>) -> Self {
         self.actions.push(Action::SetVar {
             scope,
             name: name.to_string(),
-            value,
+            value: value.into(),
         });
         self
     }


### PR DESCRIPTION
Summary: This makes it more ergonomic to go from native types to TypedData and
vice-versa.
For instance, one can now create a `TypedData` using either:

- TypedData::from(123u32)
- 123u32.into()

Or convert from TypedData to native types with:
- TypedData::UInt64(42).try_into()
- bool::try_from(TypedData::Bool(true))

The implementation also handle conversions to `Option<T>` when TypeData variant
is TypeData::Null

Test Plan: Added unittests