### PR TITLE
disconnect: look up for "status-code", not "max-frame-size"

### DIFF
--- a/src/frames/haproxy_disconnect.rs
+++ b/src/frames/haproxy_disconnect.rs
@@ -82,7 +82,7 @@ impl TryFrom<FramePayload> for HaproxyDisconnect {
         // Ensure that the payload is a KVList
         if let FramePayload::KVList(kv_list) = payload {
             let status_code = kv_list
-                .get("max-frame-size")
+                .get("status-code")
                 .and_then(|v| match v {
                     TypedData::UInt32(val) => Some(*val),
                     _ => None,


### PR DESCRIPTION
Summary: Disconnect messages were not handled properly and triggering error such as:
```
{
    "message":"Frame read error: Custom { kind: InvalidData, error: \"Failed to parse frame: Error(Error {
        input: [2, 0, 0, 0, 1, 0, 0, 11, 115, 116, 97, 116, 117, 115, 45, 99, 111, 100, 101, 3, 0, 7, 109, 101, 115, 115, 97, 103, 101, 8, 6, 110, 111, 114, 109, 97, 108],
        code: Tag
    })\"
}"
```

Test Plan: Added a test with a crafted HAPROXY-DISCONNECT and reproduced the error. Fixed the disconnect parsing, test is passing.
