### PR TITLE
reexport semver::Version

### DIFF
--- a/examples/agent_socket.rs
+++ b/examples/agent_socket.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 use futures::{SinkExt, StreamExt};
-use semver::Version;
 use spop::{
-    SpopCodec, SpopFrame,
+    SpopCodec, SpopFrame, Version,
     actions::VarScope,
     frame::{FramePayload, FrameType},
     frames::{Ack, AgentDisconnect, AgentHello, FrameCapabilities, HaproxyHello},

--- a/examples/agent_tcp.rs
+++ b/examples/agent_tcp.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 use futures::{SinkExt, StreamExt};
-use semver::Version;
 use spop::{
-    SpopCodec, SpopFrame,
+    SpopCodec, SpopFrame, Version,
     actions::VarScope,
     frame::{FramePayload, FrameType},
     frames::{Ack, AgentDisconnect, AgentHello, FrameCapabilities, HaproxyHello},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub use self::varint::{decode_varint, encode_varint};
 pub mod codec;
 pub use self::codec::SpopCodec;
 
+pub use semver::Version;
+
 /// core trait for the SPOP frame
 ///
 /// <https://github.com/haproxy/haproxy/blob/master/doc/SPOE.txt#L673>


### PR DESCRIPTION
This avoids crates from having to add semver as an explicit dependency when working with an AgentHello

- [x] Have you test the code?
- [x] Have you check that the existing tests are passing?
- [x] The destination branch is **develop**?
