### PR TITLE
frame: store borrowed values

### DIFF
--- a/examples/agent_socket.rs
+++ b/examples/agent_socket.rs
@@ -109,7 +109,7 @@ async fn handle_connection(u_stream: UnixStream) -> Result<()> {
                     // Create the Ack frame
                     let mut ack = Ack::new(frame.metadata().stream_id, frame.metadata().frame_id);
 
-                    for message in messages {
+                    for message in *messages {
                         match message.name.as_str() {
                             "check-client-ip" => {
                                 let random_value: u32 = rand::random_range(0..100);

--- a/examples/agent_tcp.rs
+++ b/examples/agent_tcp.rs
@@ -91,7 +91,7 @@ async fn handle_connection(u_stream: TcpStream) -> Result<()> {
                     // Create the Ack frame
                     let mut ack = Ack::new(frame.metadata().stream_id, frame.metadata().frame_id);
 
-                    for message in messages {
+                    for message in *messages {
                         match message.name.as_str() {
                             "check-client-ip" => {
                                 let random_value: u32 = rand::random_range(0..100);

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -131,9 +131,9 @@ impl Metadata {
 ///     KV-VALUE         : <TYPED-DATA>
 /// ```
 #[derive(Debug)]
-pub enum FramePayload {
-    ListOfMessages(Vec<Message>),
-    ListOfActions(Vec<Action>),
+pub enum FramePayload<'a> {
+    ListOfMessages(&'a [Message]),
+    ListOfActions(&'a [Action]),
     KVList(HashMap<String, TypedData>),
 }
 

--- a/src/frames/ack.rs
+++ b/src/frames/ack.rs
@@ -4,6 +4,7 @@ use crate::{
     frame::{FrameFlags, FramePayload, FrameType, Metadata},
     types::TypedData,
 };
+use std::borrow::Cow;
 
 /// Frame Ack
 ///
@@ -63,15 +64,15 @@ impl SpopFrame for Ack {
         &FrameType::Ack
     }
 
-    fn metadata(&self) -> Metadata {
-        Metadata {
+    fn metadata(&self) -> Cow<'_, Metadata> {
+        Cow::Owned(Metadata {
             flags: FrameFlags::new(true, false), // FIN flag set, ABORT flag not set
             stream_id: self.stream_id,
             frame_id: self.frame_id,
-        }
+        })
     }
 
-    fn payload(&self) -> FramePayload {
-        FramePayload::ListOfActions(self.actions.clone())
+    fn payload(&self) -> FramePayload<'_> {
+        FramePayload::ListOfActions(&self.actions)
     }
 }

--- a/src/frames/agent_disconnect.rs
+++ b/src/frames/agent_disconnect.rs
@@ -3,7 +3,7 @@ use crate::{
     frame::{FrameFlags, FramePayload, FrameType, Metadata},
     types::TypedData,
 };
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 /// Frame AGENT-DISCONNECT
 ///
@@ -44,15 +44,15 @@ impl SpopFrame for AgentDisconnect {
         &FrameType::AgentDisconnect
     }
 
-    fn metadata(&self) -> Metadata {
-        Metadata {
+    fn metadata(&self) -> Cow<'_, Metadata> {
+        Cow::Owned(Metadata {
             flags: FrameFlags::new(true, false), // FIN flag set, ABORT flag not set
             stream_id: 0,
             frame_id: 0,
-        }
+        })
     }
 
-    fn payload(&self) -> FramePayload {
+    fn payload(&self) -> FramePayload<'_> {
         let mut map = HashMap::new();
 
         map.insert(

--- a/src/frames/agent_hello.rs
+++ b/src/frames/agent_hello.rs
@@ -5,7 +5,7 @@ use crate::{
     types::TypedData,
 };
 use semver::Version;
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 /// Frame AGENT-HELLO
 ///
@@ -58,15 +58,15 @@ impl SpopFrame for AgentHello {
         &FrameType::AgentHello
     }
 
-    fn metadata(&self) -> Metadata {
-        Metadata {
+    fn metadata(&self) -> Cow<'_, Metadata> {
+        Cow::Owned(Metadata {
             flags: FrameFlags::new(true, false), // FIN flag set, ABORT flag not set
             stream_id: 0,
             frame_id: 0,
-        }
+        })
     }
 
-    fn payload(&self) -> FramePayload {
+    fn payload(&self) -> FramePayload<'_> {
         let mut map = HashMap::new();
 
         let version_str = format!("{}.{}", self.version.major, self.version.minor);

--- a/src/frames/haproxy_disconnect.rs
+++ b/src/frames/haproxy_disconnect.rs
@@ -3,7 +3,7 @@ use crate::{
     frame::{FramePayload, FrameType, Metadata},
     types::TypedData,
 };
-use std::{collections::HashMap, convert::TryFrom};
+use std::{borrow::Cow, collections::HashMap, convert::TryFrom};
 
 /// Frame HAPROXY-DISCONNECT
 ///
@@ -67,16 +67,16 @@ impl SpopFrame for HaproxyDisconnectFrame {
         &FrameType::HaproxyDisconnect
     }
 
-    fn metadata(&self) -> Metadata {
-        self.metadata.clone()
+    fn metadata(&self) -> Cow<'_, Metadata> {
+        Cow::Borrowed(&self.metadata)
     }
 
-    fn payload(&self) -> FramePayload {
+    fn payload(&self) -> FramePayload<'_> {
         FramePayload::KVList(self.payload.to_kv_list())
     }
 }
 
-impl TryFrom<FramePayload> for HaproxyDisconnect {
+impl TryFrom<FramePayload<'_>> for HaproxyDisconnect {
     type Error = String;
 
     fn try_from(payload: FramePayload) -> Result<Self, Self::Error> {

--- a/src/frames/haproxy_hello.rs
+++ b/src/frames/haproxy_hello.rs
@@ -5,7 +5,7 @@ use crate::{
     types::TypedData,
 };
 use semver::Version;
-use std::{collections::HashMap, convert::TryFrom, str::FromStr};
+use std::{borrow::Cow, collections::HashMap, convert::TryFrom, str::FromStr};
 
 /// Frame HAPROXY-HELLO
 ///
@@ -94,7 +94,7 @@ impl HaproxyHello {
             .map(std::string::ToString::to_string)
             .collect::<Vec<_>>()
             .join(",");
-        map.insert("capabilities".into(), TypedData::String(caps_string));
+        map.insert("capabilities".to_string(), TypedData::String(caps_string));
 
         if let Some(healthcheck) = self.healthcheck {
             map.insert("healthcheck".to_string(), TypedData::Bool(healthcheck));
@@ -122,16 +122,16 @@ impl SpopFrame for HaproxyHelloFrame {
         &FrameType::HaproxyHello
     }
 
-    fn metadata(&self) -> Metadata {
-        self.metadata.clone()
+    fn metadata(&self) -> Cow<'_, Metadata> {
+        Cow::Borrowed(&self.metadata)
     }
 
-    fn payload(&self) -> FramePayload {
+    fn payload(&self) -> FramePayload<'_> {
         FramePayload::KVList(self.payload.to_kv_list())
     }
 }
 
-impl TryFrom<FramePayload> for HaproxyHello {
+impl TryFrom<FramePayload<'_>> for HaproxyHello {
     type Error = String;
 
     fn try_from(payload: FramePayload) -> Result<Self, Self::Error> {

--- a/src/frames/notify.rs
+++ b/src/frames/notify.rs
@@ -2,6 +2,7 @@ use crate::{
     SpopFrame,
     frame::{FramePayload, FrameType, Message, Metadata},
 };
+use std::borrow::Cow;
 
 /// Frame Notify
 ///
@@ -29,11 +30,11 @@ impl SpopFrame for NotifyFrame {
         &FrameType::Notify
     }
 
-    fn metadata(&self) -> Metadata {
-        self.metadata.clone()
+    fn metadata(&self) -> Cow<'_, Metadata> {
+        Cow::Borrowed(&self.metadata)
     }
 
-    fn payload(&self) -> FramePayload {
-        FramePayload::ListOfMessages(self.messages.clone())
+    fn payload(&self) -> FramePayload<'_> {
+        FramePayload::ListOfMessages(&self.messages)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ pub use self::codec::SpopCodec;
 
 pub use semver::Version;
 
+use std::borrow::Cow;
+
 /// core trait for the SPOP frame
 ///
 /// <https://github.com/haproxy/haproxy/blob/master/doc/SPOE.txt#L673>
@@ -96,8 +98,8 @@ pub use semver::Version;
 /// ```
 pub trait SpopFrame: std::fmt::Debug + Send {
     fn frame_type(&self) -> &FrameType;
-    fn metadata(&self) -> Metadata;
-    fn payload(&self) -> FramePayload;
+    fn metadata(&self) -> Cow<'_, Metadata>;
+    fn payload(&self) -> FramePayload<'_>;
 
     /// # Errors
     ///
@@ -138,7 +140,7 @@ fn encode_payload(payload: &FramePayload, buf: &mut Vec<u8>) -> std::io::Result<
         FramePayload::ListOfActions(actions) => {
             // ACTION-SET-VAR  : <SET-VAR:1 byte><NB-ARGS:1 byte><VAR-SCOPE:1 byte><VAR-NAME><VAR-VALUE>
 
-            for action in actions {
+            for action in *actions {
                 match action {
                     Action::SetVar { scope, name, value } => {
                         // Action type: SET-VAR (1 byte)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -163,7 +163,7 @@ pub fn parse_frame(input: &[u8]) -> IResult<&[u8], Box<dyn SpopFrame>> {
 }
 
 /// Parse entire KV-LIST payload
-fn parse_key_value_pairs(input: &[u8]) -> IResult<&[u8], FramePayload> {
+fn parse_key_value_pairs(input: &[u8]) -> IResult<&[u8], FramePayload<'_>> {
     // Create the parser combinator chain
     let mut parser = all_consuming(many0(complete(parse_key_value_pair)));
 

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -22,11 +22,11 @@ pub fn encode_varint(i: u64) -> Vec<u8> {
     if i < 240 {
         buf.push(i as u8);
     } else {
-        buf.push((i | 240) as u8);
+        buf.push((i | 0b1111_0000) as u8);
         let mut i = (i - 240) >> 4;
 
         while i >= 128 {
-            buf.push((i | 128) as u8);
+            buf.push((i | 0b1000_0000) as u8);
             i = (i - 128) >> 7;
         }
 


### PR DESCRIPTION
Reduces the amount of some allocations. I am aware that this is a breaking change but in my application this takes out a large chunk of them and now I'm mainly waiting for syscalls ^^'

Maybe it could be a possibility to pre-allocate the entire serialization buffer as well, I'd do that in a separate PR though if I end up looking into that more.

---

- [x] Have you test the code?
- [x] Have you check that the existing tests are passing?
- [x] The destination branch is **develop**?
